### PR TITLE
User table

### DIFF
--- a/application/tmp/webister/migrations/user.sql
+++ b/application/tmp/webister/migrations/user.sql
@@ -1,0 +1,9 @@
+CREATE TABLE user (
+    id BIGINT(20) UNSIGNED AUTO_INCREMENT PRIMARY KEY, 
+    username varchar(50),
+    password varchar(80),
+    email varchar(254) DEFAULT NULL,
+    bandwidth TEXT,
+    diskspace TEXT,
+    port vachar(4)
+)


### PR DESCRIPTION
Table Naming Dilemma Singular vs. Plural Names

I had same question, and after reading all answers here I definitely stay with SINGULAR, reasons:

Reason 1 (Concept). You can think of bag containing apples like "AppleBag", it doesn't matter if contains 0, 1 or a million apples, it is always the same bag. Tables are just that, containers, the table name must describe what it contains, not how much data it contains. Additionally, the plural concept is more about a spoken language one (actually to determine whether there is one or more).

Reason 2. (Convenience). it is easier come out with singular names, than with plural ones. Objects can have irregular plurals or not plural at all, but will always have a singular one (with few exceptions like News).

    Customer
    Order
    User
    Status
    News

Reason 3. (Aesthetic and Order). Specially in master-detail scenarios, this reads better, aligns better by name, and have more logical order (Master first, Detail second):

    1.Order
    2.OrderDetail

Compared to:

    1.OrderDetails
    2.Orders

Reason 4 (Simplicity). Put all together, Table Names, Primary Keys, Relationships, Entity Classes... is better to be aware of only one name (singular) instead of two (singular class, plural table, singular field, singular-plural master-detail...)

    Customer
    Customer.CustomerID
    CustomerAddress
    public Class Customer {...}
    SELECT FROM Customer WHERE CustomerID = 100

Once you know you are dealing with "Customer", you can be sure you will use the same word for all of your database interaction needs.

Reason 5. (Globalization). The world is getting smaller, you may have a team of different nationalities, not everybody has English as native language. Would be easier for a non-native English language programmer to think of "Repository" than of "Repositories", or avoid them type "Statuses" instead of "Status". Having singular names can lead to less errors caused by typos, save time by avoid spending extra seconds to think "is it Child or Children?", hence improving productivity.

Reason 6. (Why not?). It can even save you writing time, save you disk space, and even make your computer keyboard lasts more!

    SELECT Customer.CustomerName FROM Customer WHERE Customer.CustomerID = 100
    SELECT Customers.CustomerName FROM Customers WHERE Customers.CustomerID = 100

You have saved 3 letters, 3 bytes, 3 extra keyboard hits :)

And finally, you can name those ones messing up with reserved names like:

    User > LoginUser, AppUser, SystemUser, CMSUser,...

Or use the infamous squared brackets [User] 